### PR TITLE
Implement hardware acceleration

### DIFF
--- a/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
@@ -258,7 +258,9 @@ namespace FileConverter.ConversionJobs
                         VideoEncodingSpeed videoEncodingSpeed = this.ConversionPreset.GetSettingsValue<VideoEncodingSpeed>(ConversionPreset.ConversionSettingKeys.VideoEncodingSpeed);
                         int audioEncodingBitrate = this.ConversionPreset.GetSettingsValue<int>(ConversionPreset.ConversionSettingKeys.AudioBitrate);
 
-                        string transformArgs = ConversionJob_FFMPEG.ComputeTransformArgs(this.ConversionPreset);
+                        Helpers.HardwareAccelerationMode hwAccel = settingsService.Settings.HardwareAccelerationMode;
+
+                        string transformArgs = ConversionJob_FFMPEG.ComputeTransformArgs(this.ConversionPreset, hwAccel);
                         string videoFilteringArgs = ConversionJob_FFMPEG.Encapsulate("-vf", transformArgs);
 
                         string audioArgs = "-an";
@@ -269,10 +271,10 @@ namespace FileConverter.ConversionJobs
 
                         string videoCodec = "libx264";
                         string hwAccelArg = "";
-                        if (settingsService.Settings.HardwareAccelerationMode == Helpers.HardwareAccelerationMode.CUDA)
+                        if (hwAccel == Helpers.HardwareAccelerationMode.CUDA)
                         {
                             videoCodec = "h264_nvenc";
-                            hwAccelArg = "-hwaccel cuda";
+                            hwAccelArg = "-hwaccel cuda -hwaccel_output_format cuda";
                         }
 
                         string encoderArgs = string.Format(

--- a/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
@@ -265,13 +265,13 @@ namespace FileConverter.ConversionJobs
                         }
 
                         string encoderArgs = string.Format(
-                            "-c:v libx264 -preset {0} -crf {1} {2} {3}",
+                            "-c:v h264_nvenc -preset {0} -crf {1} {2} {3}",
                             this.H264EncodingSpeedToPreset(videoEncodingSpeed), 
                             this.H264QualityToCRF(videoEncodingQuality),
                             audioArgs, 
                             videoFilteringArgs);
 
-                        string arguments = string.Format("-n -stats -i \"{0}\" {2} \"{1}\"", this.InputFilePath, this.OutputFilePath, encoderArgs);
+                        string arguments = string.Format("-n -stats -hwaccel cuda -i \"{0}\" {2} \"{1}\"", this.InputFilePath, this.OutputFilePath, encoderArgs);
 
                         this.ffmpegArgumentStringByPass.Add(new FFMpegPass(arguments));
                     }

--- a/Application/FileConverter/FileConverter.csproj
+++ b/Application/FileConverter/FileConverter.csproj
@@ -216,6 +216,7 @@
     <Compile Include="Services\SettingsService.cs" />
     <Compile Include="Services\UpgradeService.cs" />
     <Compile Include="Services\UpgradeVersionDescription.cs" />
+    <Compile Include="ValueConverters\HardwareAccelerationModeToString.cs" />
     <Compile Include="ValueConverters\ConversionJobsToProgressState.cs" />
     <Compile Include="ValueConverters\ApplicationVersionToApplicationName.cs" />
     <Compile Include="ConversionPreset\ConversionPreset.cs" />

--- a/Application/FileConverter/Helpers.cs
+++ b/Application/FileConverter/Helpers.cs
@@ -349,5 +349,11 @@ namespace FileConverter
 
             public const string Misc = "Misc";
         }
+
+        public enum HardwareAccelerationMode
+        {
+            Off,
+            CUDA
+        }
     }
 }

--- a/Application/FileConverter/Properties/Resources.Designer.cs
+++ b/Application/FileConverter/Properties/Resources.Designer.cs
@@ -763,6 +763,78 @@ namespace FileConverter.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hardware acceleration mode.
+        /// </summary>
+        public static string HardwareAccelerationMode {
+            get {
+                return ResourceManager.GetString("HardwareAccelerationMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Advanced Media Framework (AMD).
+        /// </summary>
+        public static string HardwareAccelerationModeAMFName {
+            get {
+                return ResourceManager.GetString("HardwareAccelerationModeAMFName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CUDA (Nvidia).
+        /// </summary>
+        public static string HardwareAccelerationModeCUDAName {
+            get {
+                return ResourceManager.GetString("HardwareAccelerationModeCUDAName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Direct3D 11.
+        /// </summary>
+        public static string HardwareAccelerationModeD3D11Name {
+            get {
+                return ResourceManager.GetString("HardwareAccelerationModeD3D11Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Direct3D 9/DXVA2.
+        /// </summary>
+        public static string HardwareAccelerationModeDXVA2Name {
+            get {
+                return ResourceManager.GetString("HardwareAccelerationModeDXVA2Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Off.
+        /// </summary>
+        public static string HardwareAccelerationModeOffName {
+            get {
+                return ResourceManager.GetString("HardwareAccelerationModeOffName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OpenCL.
+        /// </summary>
+        public static string HardwareAccelerationModeOpenCLName {
+            get {
+                return ResourceManager.GetString("HardwareAccelerationModeOpenCLName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Vulkan.
+        /// </summary>
+        public static string HardwareAccelerationModeVulkanName {
+            get {
+                return ResourceManager.GetString("HardwareAccelerationModeVulkanName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to help ?.
         /// </summary>
         public static string Help {

--- a/Application/FileConverter/Properties/Resources.resx
+++ b/Application/FileConverter/Properties/Resources.resx
@@ -592,4 +592,28 @@ use maj for uppercase version</value>
   <data name="CopyFilesInClipboardAfterConversion" xml:space="preserve">
     <value>Copy files in clipboard after conversion</value>
   </data>
+  <data name="HardwareAccelerationMode" xml:space="preserve">
+    <value>Hardware acceleration mode</value>
+  </data>
+  <data name="HardwareAccelerationModeAMFName" xml:space="preserve">
+    <value>Advanced Media Framework (AMD)</value>
+  </data>
+  <data name="HardwareAccelerationModeCUDAName" xml:space="preserve">
+    <value>CUDA (Nvidia)</value>
+  </data>
+  <data name="HardwareAccelerationModeD3D11Name" xml:space="preserve">
+    <value>Direct3D 11</value>
+  </data>
+  <data name="HardwareAccelerationModeDXVA2Name" xml:space="preserve">
+    <value>Direct3D 9/DXVA2</value>
+  </data>
+  <data name="HardwareAccelerationModeOffName" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HardwareAccelerationModeOpenCLName" xml:space="preserve">
+    <value>OpenCL</value>
+  </data>
+  <data name="HardwareAccelerationModeVulkanName" xml:space="preserve">
+    <value>Vulkan</value>
+  </data>
 </root>

--- a/Application/FileConverter/Settings.cs
+++ b/Application/FileConverter/Settings.cs
@@ -22,6 +22,7 @@ namespace FileConverter
         private CultureInfo applicationLanguage;
         private int maximumNumberOfSimultaneousConversions;
         private bool copyFilesInClipboardAfterConversion = false;
+        private Helpers.HardwareAccelerationMode hardwareAccelerationMode = Helpers.HardwareAccelerationMode.Off;
 
         public ConversionPreset GetPresetFromName(string presetName)
         {
@@ -218,6 +219,21 @@ namespace FileConverter
             set
             {
                 this.copyFilesInClipboardAfterConversion = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+        [XmlElement]
+        public Helpers.HardwareAccelerationMode HardwareAccelerationMode
+        {
+            get
+            {
+                return this.hardwareAccelerationMode;
+            }
+
+            set
+            {
+                this.hardwareAccelerationMode = value;
                 this.OnPropertyChanged();
             }
         }

--- a/Application/FileConverter/ValueConverters/HardwareAccelerationModeToString.cs
+++ b/Application/FileConverter/ValueConverters/HardwareAccelerationModeToString.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="HardwareAccelerationModeToString.cs" company="AAllard">License: http://www.gnu.org/licenses/gpl.html GPL version 3.</copyright>
+
+namespace FileConverter.ValueConverters
+{
+    using System;
+    using System.Globalization;
+    using System.Windows.Data;
+
+    public class HardwareAccelerationModeToString : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            switch (value) {
+                case Helpers.HardwareAccelerationMode.Off:
+                    return "Off";
+                case Helpers.HardwareAccelerationMode.CUDA:
+                    return "Nvidia (CUDA)";
+            }
+            return "Unknown";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Application/FileConverter/ValueConverters/HardwareAccelerationModeToString.cs
+++ b/Application/FileConverter/ValueConverters/HardwareAccelerationModeToString.cs
@@ -12,9 +12,9 @@ namespace FileConverter.ValueConverters
         {
             switch (value) {
                 case Helpers.HardwareAccelerationMode.Off:
-                    return "Off";
+                    return Properties.Resources.HardwareAccelerationModeOffName;
                 case Helpers.HardwareAccelerationMode.CUDA:
-                    return "Nvidia (CUDA)";
+                    return Properties.Resources.HardwareAccelerationModeCUDAName;
             }
             return "Unknown";
         }

--- a/Application/FileConverter/ViewModels/SettingsViewModel.cs
+++ b/Application/FileConverter/ViewModels/SettingsViewModel.cs
@@ -47,6 +47,7 @@ namespace FileConverter.ViewModels
 
         private ListCollectionView outputTypes;
         private CultureInfo[] supportedCultures;
+        private Helpers.HardwareAccelerationMode[] hardwareAccelerationModes = { Helpers.HardwareAccelerationMode.Off, Helpers.HardwareAccelerationMode.CUDA };
 
         public event Action OnPresetCreated;
         public event Action OnFolderCreated;
@@ -228,6 +229,16 @@ namespace FileConverter.ViewModels
             set
             {
                 this.supportedCultures = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+        public Helpers.HardwareAccelerationMode[] HardwareAccelerationModes
+        {
+            get => this.hardwareAccelerationModes;
+            set
+            {
+                this.hardwareAccelerationModes = value;
                 this.OnPropertyChanged();
             }
         }

--- a/Application/FileConverter/Views/Resources/ConversionPresetTemplates.xaml
+++ b/Application/FileConverter/Views/Resources/ConversionPresetTemplates.xaml
@@ -20,6 +20,7 @@
     <generic:FormatStringConverter x:Key="FormatStringConverter"/>
     <valueConverters:OutputTypeEnumToViewModel x:Key="OutputTypeEnumToViewModel"/>
     <valueConverters:ConversionSettingsRelevant x:Key="ConversionSettingsRelevant"/>
+    <valueConverters:HardwareAccelerationModeToString x:Key="HardwareAccelerationModeToString"/>
 
     <generic:ValueConverterGroup x:Key="ConversionSettingsToEnum">
         <valueConverters:ConversionSettingsToString/>

--- a/Application/FileConverter/Views/SettingsWindow.xaml
+++ b/Application/FileConverter/Views/SettingsWindow.xaml
@@ -401,7 +401,7 @@
                     <Label Grid.Row="5" Grid.Column="0" Content="{x:Static project:Resources.CopyFilesInClipboardAfterConversion}" HorizontalAlignment="Right" Margin="0,0,5,0"/>
                     <CheckBox Grid.Row="5" Grid.Column="1" x:Name="CopyFilesInClipboardAfterConversionCheckBox" IsChecked="{Binding Settings.CopyFilesInClipboardAfterConversion, Mode=TwoWay}"  Margin="0,5,0,5" />
 
-                    <Label Grid.Row="6" Grid.Column="0" Content="Hardware acceleration mode" HorizontalAlignment="Right" Margin="0,0,5,0"/>
+                    <Label Grid.Row="6" Grid.Column="0" Content="{x:Static project:Resources.HardwareAccelerationMode}" HorizontalAlignment="Right" Margin="0,0,5,0"/>
                     <ComboBox Grid.Row="6" Grid.Column="1" ItemsSource="{Binding HardwareAccelerationModes, Mode=OneTime}" Margin="0,0,0,1"
                               SelectedValue="{Binding Settings.HardwareAccelerationMode, Mode=TwoWay}">
                         <ComboBox.ItemTemplate>

--- a/Application/FileConverter/Views/SettingsWindow.xaml
+++ b/Application/FileConverter/Views/SettingsWindow.xaml
@@ -369,6 +369,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
                     <Label Grid.Row="0" Grid.Column="0" Content="{x:Static project:Resources.Language}" HorizontalAlignment="Right" Margin="0,0,5,0"/>
@@ -399,6 +400,16 @@
 
                     <Label Grid.Row="5" Grid.Column="0" Content="{x:Static project:Resources.CopyFilesInClipboardAfterConversion}" HorizontalAlignment="Right" Margin="0,0,5,0"/>
                     <CheckBox Grid.Row="5" Grid.Column="1" x:Name="CopyFilesInClipboardAfterConversionCheckBox" IsChecked="{Binding Settings.CopyFilesInClipboardAfterConversion, Mode=TwoWay}"  Margin="0,5,0,5" />
+
+                    <Label Grid.Row="6" Grid.Column="0" Content="Hardware acceleration mode" HorizontalAlignment="Right" Margin="0,0,5,0"/>
+                    <ComboBox Grid.Row="6" Grid.Column="1" ItemsSource="{Binding HardwareAccelerationModes, Mode=OneTime}" Margin="0,0,0,1"
+                              SelectedValue="{Binding Settings.HardwareAccelerationMode, Mode=TwoWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <ContentPresenter Content="{Binding Converter={StaticResource HardwareAccelerationModeToString}}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
                 </Grid>
             </TabItem>
 


### PR DESCRIPTION
This PR addresses Issue #392.

I've added some Nvidia CUDA FFMPEG arguments for the mp4 format for now, but this is a good start. What remains is:

- [ ] Supporting AMD acceleration
- [x] Supporting NVIDIA acceleration
- [ ] Implementing the arguments in other video formats as well (right now only for mp4)
- [x] Use localization for the option strings
- [X] Adding a setting in the program interface to control what type of acceleration to use (off by default)
- [X] _Maybe_: hardware acceleration for the _entire_ transcoding process. Right now only encoding and decoding are accelerated.
  - This isn't a convenient feat. For CUDA it requires changing filter names from `scale` to `scale_cuda`, or `crf` into `qp` for example. I tried doing this but couldn't get it to not error. It requires much experimentation.

All help is greatly appreciated 😀 This is the first C# program I edit...

The results I got adding these arguments (which accelerate only the encode/decode part of the process) are **2-3x faster** than before, transcoding a 176 MB video into ~8MB using the `To Mp4 (low quality)` preset.

## Development
I couldn't find much information on how to contribute to this program, but this is what I've learned so far:

### Installation
The `Magick.Native-Q16-x64.dll` file must be copied to `bin/x64/Debug` for the program to compile. To obtain this file you need to follow the [Magick.NET compilation guide](https://github.com/dlemstra/Magick.NET/blob/main/Building.md) and then grab it from `C:\Users\xxxx\.nuget\packages\magick.native`.

### Testing
The project can be built in its entirety, and then the installer can be run, but this requires a system restart. A more efficient option is calling `FileConverter.exe` directly. After building the `FileConverter` solution, you should be able to find `Application/FileConverter/bin/x64/Debug/FileConverter.exe`

Opening this file will give you the tutorial window. But if you run it from the command line like so:
```ps
.\FileConverter.exe --verbose --conversion-preset "To Mp4 (low quality)" "C:\Users\DevAccount\Desktop\cs.mp4"
```
It is equivalent to right clicking a preset in the context menu, without all the extra steps.

## Resources:
- https://docs.nvidia.com/video-technologies/video-codec-sdk/12.0/ffmpeg-with-nvidia-gpu/index.html
- https://trac.ffmpeg.org/wiki/HWAccelIntro
- https://github.com/HeiSir2014/ffmpeg-wiki
- https://stackoverflow.com/a/55747785
- https://lists.ffmpeg.org/pipermail/ffmpeg-user/2017-July/036820.html
- various StackExchange answers you might find
