### PR TITLE
Add gif to image support and update imageMagick to 14.2

### DIFF
--- a/Application/FileConverter/App.config
+++ b/Application/FileConverter/App.config
@@ -22,6 +22,10 @@
                 <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Magick.NET.Core" publicKeyToken="2004825badfa91ec" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-14.2.0.0" newVersion="14.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
 </configuration>

--- a/Application/FileConverter/ConversionJobs/ConversionJobFactory.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJobFactory.cs
@@ -43,8 +43,9 @@ namespace FileConverter.ConversionJobs
                 return new ConversionJob_ImageMagick(conversionPreset, inputFilePath);
             }
 
-            if (Helpers.GetExtensionCategory(inputFileExtension) == Helpers.InputCategoryNames.Image ||
-                Helpers.GetExtensionCategory(inputFileExtension) == Helpers.InputCategoryNames.Document)
+            if (conversionPreset.OutputType == OutputType.Jpg ||
+                conversionPreset.OutputType == OutputType.Png ||
+                conversionPreset.OutputType == OutputType.Webp)
             {
                 return new ConversionJob_ImageMagick(conversionPreset, inputFilePath);
             }

--- a/Application/FileConverter/ConversionJobs/ConversionJob_ImageMagick.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob_ImageMagick.cs
@@ -144,7 +144,7 @@ namespace FileConverter.ConversionJobs
                     }
 
                     this.ConvertImage(image, true);
-                    
+
                     this.CurrentOutputFilePathIndex++;
                 }
             }
@@ -181,7 +181,7 @@ namespace FileConverter.ConversionJobs
                 bool clampSizeToPowerOf2 = this.ConversionPreset.GetSettingsValue<bool>(ConversionPreset.ConversionSettingKeys.ImageClampSizePowerOf2);
                 if (clampSizeToPowerOf2)
                 {
-                    int referenceSize = System.Math.Min(image.Width, image.Height);
+                    int referenceSize = System.Math.Min((int)image.Width, (int)image.Height);
                     int size = 2;
                     while (size * 2 <= referenceSize)
                     {
@@ -190,7 +190,7 @@ namespace FileConverter.ConversionJobs
 
                     Debug.Log($"Clamp size to the nearest power of 2 size (from {image.Width}x{image.Height} to {size}x{size}).");
 
-                    image.Scale(size, size);
+                    image.Scale((uint)size, (uint)size);
                 }
             }
 
@@ -199,12 +199,12 @@ namespace FileConverter.ConversionJobs
                 int maximumSize = this.ConversionPreset.GetSettingsValue<int>(ConversionPreset.ConversionSettingKeys.ImageMaximumSize);
                 if (maximumSize > 0)
                 {
-                    int width = System.Math.Min(image.Width, maximumSize);
-                    int height = System.Math.Min(image.Height, maximumSize);
+                    int width = System.Math.Min((int)image.Width, (int)maximumSize);
+                    int height = System.Math.Min((int)image.Height, maximumSize);
 
                     Debug.Log($"Clamp size to maximum size of {width}x{width} (from {image.Width}x{image.Height} to {width}x{height}).");
 
-                    image.Scale(width, height);
+                    image.Scale((uint)width, (uint)height);
                 }
             }
 
@@ -217,7 +217,7 @@ namespace FileConverter.ConversionJobs
                     break;
 
                 case OutputType.Jpg:
-                    image.Quality = this.ConversionPreset.GetSettingsValue<int>(ConversionPreset.ConversionSettingKeys.ImageQuality);
+                    image.Quality = (uint)this.ConversionPreset.GetSettingsValue<int>(ConversionPreset.ConversionSettingKeys.ImageQuality);
                     break;
 
                 case OutputType.Pdf:
@@ -226,7 +226,7 @@ namespace FileConverter.ConversionJobs
                     break;
 
                 case OutputType.Webp:
-                    image.Quality = this.ConversionPreset.GetSettingsValue<int>(ConversionPreset.ConversionSettingKeys.ImageQuality);
+                    image.Quality = (uint)this.ConversionPreset.GetSettingsValue<int>(ConversionPreset.ConversionSettingKeys.ImageQuality);
                     break;
 
                 default:

--- a/Application/FileConverter/ConversionJobs/ConversionJob_ImageMagick.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob_ImageMagick.cs
@@ -86,6 +86,12 @@ namespace FileConverter.ConversionJobs
                         readSettings.Format = MagickFormat.Dng;
                         break;
 
+                    case ".gif":
+                        // Get the first frame of the gif for conversion.
+                        // Maybe in the future make this user selectable.
+                        readSettings.FrameIndex = 0;
+                        break;
+
                     default:
                         break;
                 }

--- a/Application/FileConverter/FileConverter.csproj
+++ b/Application/FileConverter/FileConverter.csproj
@@ -72,13 +72,11 @@
     <Reference Include="CommunityToolkit.Mvvm, Version=8.2.0.0, Culture=neutral, PublicKeyToken=4aff67a105548ee2, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommunityToolkit.Mvvm.8.2.2\lib\netstandard2.0\CommunityToolkit.Mvvm.dll</HintPath>
     </Reference>
-    <Reference Include="Magick.NET-Q16-AnyCPU, Version=13.5.0.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Magick.NET-Q16-AnyCPU.13.5.0\lib\netstandard20\Magick.NET-Q16-AnyCPU.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Magick.NET-Q16-AnyCPU, Version=14.2.0.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Magick.NET-Q16-AnyCPU.14.2.0\lib\netstandard20\Magick.NET-Q16-AnyCPU.dll</HintPath>
     </Reference>
-    <Reference Include="Magick.NET.Core, Version=13.5.0.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Magick.NET.Core.13.5.0\lib\netstandard20\Magick.NET.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Magick.NET.Core, Version=14.2.0.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Magick.NET.Core.14.2.0\lib\netstandard20\Magick.NET.Core.dll</HintPath>
     </Reference>
     <Reference Include="Markdown.Xaml">
       <HintPath>..\..\Middleware\Markdown.Xaml.dll</HintPath>
@@ -456,15 +454,15 @@ if %25errorlevel%25 leq 1 exit 0 else exit %25errorlevel%25
 robocopy $(TargetDir) $(TargetDir)\Languages "$(TargetName).resources.dll" /MOVE /S /XD Languages /XL /IS /IT /NFL /NDL /NJH /NJS /NC /NS /NP
 if %25errorlevel%25 leq 1 exit 0 else exit %25errorlevel%25</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\..\packages\Magick.NET-Q16-AnyCPU.13.5.0\build\netstandard20\Magick.NET-Q16-AnyCPU.targets" Condition="Exists('..\..\packages\Magick.NET-Q16-AnyCPU.13.5.0\build\netstandard20\Magick.NET-Q16-AnyCPU.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Magick.NET-Q16-AnyCPU.13.5.0\build\netstandard20\Magick.NET-Q16-AnyCPU.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Magick.NET-Q16-AnyCPU.13.5.0\build\netstandard20\Magick.NET-Q16-AnyCPU.targets'))" />
     <Error Condition="!Exists('..\..\packages\CommunityToolkit.Mvvm.8.2.2\build\netstandard2.0\CommunityToolkit.Mvvm.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\CommunityToolkit.Mvvm.8.2.2\build\netstandard2.0\CommunityToolkit.Mvvm.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Magick.NET-Q16-AnyCPU.14.2.0\build\netstandard20\Magick.NET-Q16-AnyCPU.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Magick.NET-Q16-AnyCPU.14.2.0\build\netstandard20\Magick.NET-Q16-AnyCPU.targets'))" />
   </Target>
   <Import Project="..\..\packages\CommunityToolkit.Mvvm.8.2.2\build\netstandard2.0\CommunityToolkit.Mvvm.targets" Condition="Exists('..\..\packages\CommunityToolkit.Mvvm.8.2.2\build\netstandard2.0\CommunityToolkit.Mvvm.targets')" />
+  <Import Project="..\..\packages\Magick.NET-Q16-AnyCPU.14.2.0\build\netstandard20\Magick.NET-Q16-AnyCPU.targets" Condition="Exists('..\..\packages\Magick.NET-Q16-AnyCPU.14.2.0\build\netstandard20\Magick.NET-Q16-AnyCPU.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Application/FileConverter/Helpers.cs
+++ b/Application/FileConverter/Helpers.cs
@@ -216,7 +216,7 @@ namespace FileConverter
                 case OutputType.Jpg:
                 case OutputType.Png:
                 case OutputType.Webp:
-                    return category == InputCategoryNames.Image || category == InputCategoryNames.Document;
+                    return category == InputCategoryNames.Image || category == InputCategoryNames.Document || category == InputCategoryNames.AnimatedImage;
 
                 case OutputType.Gif:
                     return category == InputCategoryNames.Image || category == InputCategoryNames.Video || category == InputCategoryNames.AnimatedImage;

--- a/Application/FileConverter/packages.config
+++ b/Application/FileConverter/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommunityToolkit.Mvvm" version="8.2.2" targetFramework="net48" />
-  <package id="Magick.NET.Core" version="13.5.0" targetFramework="net48" />
-  <package id="Magick.NET-Q16-AnyCPU" version="13.5.0" targetFramework="net48" />
+  <package id="Magick.NET.Core" version="14.2.0" targetFramework="net48" />
+  <package id="Magick.NET-Q16-AnyCPU" version="14.2.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.Extensions.DependencyInjection" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" targetFramework="net48" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - New: Persian translation (thanks to MrHero118).
 - Fixes: Hebrew translation issues (thanks to AshiVered).
 - New: Add Gif to Image conversion support (issue #433, #115)
+- Fixes: Update to Magick.NET.Core 14.2.0 (issue #527)
 
 ## Version 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New: Persian translation (thanks to MrHero118).
 - Fixes: Hebrew translation issues (thanks to AshiVered).
+- New: Add Gif to Image conversion support (issue #433, #115)
 
 ## Version 2.0.2
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ File converter uses the following middlewares:
 **ffmpeg** (v6.1.1) as file conversion software.
 Thanks to ffmpeg devs for this awesome open source file conversion tool. [Web site link](https://ffmpeg.org)
 
-**ImageMagick** (v13.5) as image edition and conversion software.
+**ImageMagick** (v14.2) as image edition and conversion software.
 Thanks to image magick devs for this awesome open source image edition software suite.  [Web site link](http://imagemagick.net)
 And thanks to dlemstra for the C# wrapper of this software. [Github link](https://github.com/ImageMagick/ImageMagick)
 


### PR DESCRIPTION
It is really handy to be able to convert an animated gif to a still image. Most of the time, this just involves grabbing the first frame of the gif. This change implements that. In the future, the option to be able to select what frame to get should maybe be added, but for now this covers maybe 90% of the use cases for gif to img. 

Another problem that I had that was also in #527 was that IOS with their HEIC file format did not convert. Only newer versions of ImageMagick fixed the problem, so I updated to 14.2. This required casting some variables from `int` to `uint` though. 

I installed it after building, and it works great.  

Let me know what you think or if you have any suggestions for this. Thanks!

Closes #433 
Closes #115
Closes #527 
Closes #493
Closes #512
Closes #543

