### PR TITLE
Added alac support

### DIFF
--- a/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
@@ -122,6 +122,17 @@ namespace FileConverter.ConversionJobs
                     }
 
                     break;
+                case OutputType.m4a:
+                    {
+                        string channelArgs = ConversionJob_FFMPEG.ComputeAudioChannelArgs(this.ConversionPreset);
+                        //https://stackoverflow.com/questions/62486428/using-ffmpeg-to-convert-flac-to-alac-with-cover-art
+                        string encoderArgs = $"-c:a alac -c:v copy {channelArgs}";
+
+                        string arguments = string.Format("-n -stats -i \"{0}\" {2} \"{1}\"", this.InputFilePath, this.OutputFilePath, encoderArgs);
+
+                        this.ffmpegArgumentStringByPass.Add(new FFMpegPass(arguments));
+                    }
+                    break;
 
                 case OutputType.Avi:
                     {

--- a/Application/FileConverter/ConversionPreset/ConversionPreset.cs
+++ b/Application/FileConverter/ConversionPreset/ConversionPreset.cs
@@ -421,6 +421,11 @@ namespace FileConverter
                     this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.EnableFFMPEGCustomCommand, "False");
                     this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.FFMPEGCustomCommand, string.Empty);
                     break;
+                case OutputType.m4a:
+                    this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.AudioChannelCount, "0");
+                    this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.EnableFFMPEGCustomCommand, "False");
+                    this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.FFMPEGCustomCommand, string.Empty);
+                    break;
 
                 case OutputType.Flac:
                     this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.AudioChannelCount, "0");

--- a/Application/FileConverter/FileConverter.csproj
+++ b/Application/FileConverter/FileConverter.csproj
@@ -278,9 +278,13 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <EmbeddedResource Include="Properties\Resources.ar-EG.resx" />
+    <EmbeddedResource Include="Properties\Resources.ar-EG.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.cs-CZ.resx" />
-    <EmbeddedResource Include="Properties\Resources.de-DE.resx" />
+    <EmbeddedResource Include="Properties\Resources.de-DE.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.fa-IR.resx" />
     <EmbeddedResource Include="Properties\Resources.he-IL.resx" />
     <EmbeddedResource Include="Properties\Resources.hi-IN.resx" />

--- a/Application/FileConverter/Helpers.cs
+++ b/Application/FileConverter/Helpers.cs
@@ -199,6 +199,7 @@ namespace FileConverter
             switch (outputType)
             {
                 case OutputType.Aac:
+                case OutputType.m4a:
                 case OutputType.Flac:
                 case OutputType.Mp3:
                 case OutputType.Ogg:

--- a/Application/FileConverter/OutputType.cs
+++ b/Application/FileConverter/OutputType.cs
@@ -7,6 +7,7 @@ namespace FileConverter
         None,
 
         Aac,
+        m4a,
         Avi,
         Flac,
         Gif,

--- a/Application/FileConverter/Settings.default.xml
+++ b/Application/FileConverter/Settings.default.xml
@@ -385,6 +385,7 @@
     </ConversionPreset>
     <ConversionPreset Name="To Aac" OutputType="Aac" IsDefaultSettings="true">
         <InputTypes>3gp</InputTypes>
+		<InputTypes>Alac</InputTypes>
         <InputTypes>3gpp</InputTypes>
         <InputTypes>avi</InputTypes>
         <InputTypes>bik</InputTypes>
@@ -419,6 +420,42 @@
         <Settings Key="FFMPEGCustomCommand" Value="" />
         <OutputFileNameTemplate>(p)(f)</OutputFileNameTemplate>
     </ConversionPreset>
+	<ConversionPreset Name="To Alac" OutputType="m4a" IsDefaultSettings="true">
+		<InputTypes>3gp</InputTypes>
+		<InputTypes>3gpp</InputTypes>
+		<InputTypes>Aac</InputTypes>
+		<InputTypes>avi</InputTypes>
+		<InputTypes>bik</InputTypes>
+		<InputTypes>flv</InputTypes>
+		<InputTypes>m4v</InputTypes>
+		<InputTypes>mkv</InputTypes>
+		<InputTypes>mov</InputTypes>
+		<InputTypes>mp4</InputTypes>
+		<InputTypes>mpg</InputTypes>
+		<InputTypes>mpeg</InputTypes>
+		<InputTypes>ogv</InputTypes>
+		<InputTypes>rm</InputTypes>
+		<InputTypes>ts</InputTypes>
+		<InputTypes>webm</InputTypes>
+		<InputTypes>wmv</InputTypes>
+		<InputTypes>aac</InputTypes>
+		<InputTypes>aiff</InputTypes>
+		<InputTypes>ape</InputTypes>
+		<InputTypes>flac</InputTypes>
+		<InputTypes>m4a</InputTypes>
+		<InputTypes>m4b</InputTypes>
+		<InputTypes>mp3</InputTypes>
+		<InputTypes>oga</InputTypes>
+		<InputTypes>ogg</InputTypes>
+		<InputTypes>opus</InputTypes>
+		<InputTypes>wav</InputTypes>
+		<InputTypes>wma</InputTypes>
+		<InputPostConversionAction>None</InputPostConversionAction>
+		<Settings Key="AudioChannelCount" Value="0" />
+		<Settings Key="EnableFFMPEGCustomCommand" Value="False" />
+		<Settings Key="FFMPEGCustomCommand" Value="" />
+		<OutputFileNameTemplate>(p)(f)</OutputFileNameTemplate>
+	</ConversionPreset>
     <ConversionPreset Name="Extract DVD to Mp4" OutputType="Mp4" IsDefaultSettings="true">
         <InputTypes>vob</InputTypes>
         <InputPostConversionAction>None</InputPostConversionAction>

--- a/Application/FileConverter/ViewModels/SettingsViewModel.cs
+++ b/Application/FileConverter/ViewModels/SettingsViewModel.cs
@@ -75,6 +75,7 @@ namespace FileConverter.ViewModels
             outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Ogg));
             outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Mp3));
             outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Aac));
+            outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.m4a));
             outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Flac));
             outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Wav));
             outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Mkv));

--- a/Application/FileConverter/Views/Resources/ConversionPresetTemplates.xaml
+++ b/Application/FileConverter/Views/Resources/ConversionPresetTemplates.xaml
@@ -163,6 +163,25 @@
         </Grid>
     </DataTemplate>
 
+    <DataTemplate x:Key="AlacSettingsDataTemplate" DataType="{x:Type fileConverter:ConversionPreset}">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <Label Grid.Row="0" Grid.Column="0" Content="{x:Static project:Resources.ChannelCountTitle}" ToolTip="{x:Static project:Resources.ChannelCountTooltip}" />
+            <DockPanel Grid.Row="0" Grid.Column="1">
+                <RadioButton Content="{x:Static project:Resources.SameChannelCountOption}" Margin="5" IsChecked="{Binding Settings, ConverterParameter=AudioChannelCount|0, Converter={StaticResource ConversionSettingsEquals}, Mode=TwoWay}" />
+                <RadioButton Content="{x:Static project:Resources.MonoOption}" Margin="5" IsChecked="{Binding Settings, ConverterParameter=AudioChannelCount|1, Converter={StaticResource ConversionSettingsEquals}, Mode=TwoWay}" />
+                <RadioButton Content="{x:Static project:Resources.StereoOption}" Margin="5" IsChecked="{Binding Settings, ConverterParameter=AudioChannelCount|2, Converter={StaticResource ConversionSettingsEquals}, Mode=TwoWay}" />
+            </DockPanel>
+        </Grid>
+    </DataTemplate>
+
     <DataTemplate x:Key="FlacSettingsDataTemplate" DataType="{x:Type fileConverter:ConversionPreset}">
         <Grid>
             <Grid.ColumnDefinitions>
@@ -620,6 +639,9 @@
         <Style.Triggers>
             <DataTrigger Binding="{Binding OutputType}" Value="Aac">
                 <Setter Property="ContentTemplate" Value="{StaticResource AacSettingsDataTemplate}"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding OutputType}" Value="Alac">
+                <Setter Property="ContentTemplate" Value="{StaticResource AlacSettingsDataTemplate}"/>
             </DataTrigger>
             <DataTrigger Binding="{Binding OutputType}" Value="Avi">
                 <Setter Property="ContentTemplate" Value="{StaticResource AviSettingsDataTemplate}"/>


### PR DESCRIPTION
**Description**
PR for Issue #437 "ALAC Output Support"

**Changes**
Apart from the revelant .cs files, the Settings.default.xml was also changed to include new ConversionPreset Node.

**Testing** 
Self-reviewed changes
Successfully converted multiple .flac file to .m4a files.
The output of the process were .m4a files with the audio encoded as ALAC.

**Related issues**
None

**Additional Notes**
Could not implement a bitrate to quality index method as implemented for AAC output type due to lack of information found. However, willing to implement, if found.
