### PR TITLE
Add avif support

### DIFF
--- a/Application/FileConverter/ConversionJobs/ConversionJobFactory.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJobFactory.cs
@@ -43,7 +43,8 @@ namespace FileConverter.ConversionJobs
                 return new ConversionJob_ImageMagick(conversionPreset, inputFilePath);
             }
 
-            if (conversionPreset.OutputType == OutputType.Jpg ||
+            if (conversionPreset.OutputType == OutputType.Avif ||
+                conversionPreset.OutputType == OutputType.Jpg ||
                 conversionPreset.OutputType == OutputType.Png ||
                 conversionPreset.OutputType == OutputType.Webp)
             {

--- a/Application/FileConverter/ConversionJobs/ConversionJob_ImageMagick.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob_ImageMagick.cs
@@ -76,6 +76,11 @@ namespace FileConverter.ConversionJobs
                 string inputExtension = System.IO.Path.GetExtension(this.InputFilePath).ToLowerInvariant();
                 switch (inputExtension)
                 {
+                    case ".avif":
+                        // Explicitly set AVIF format for proper reading
+                        readSettings.Format = MagickFormat.Avif;
+                        break;
+
                     case ".cr2":
                         // Requires an explicit image format otherwise the image is interpreted as a TIFF image.
                         readSettings.Format = MagickFormat.Cr2;
@@ -211,6 +216,10 @@ namespace FileConverter.ConversionJobs
             Debug.Log($"Convert image (output: {this.OutputFilePath}).");
             switch (this.ConversionPreset.OutputType)
             {
+                case OutputType.Avif:
+                    image.Quality = this.ConversionPreset.GetSettingsValue<uint>(ConversionPreset.ConversionSettingKeys.ImageQuality);
+                    break;
+
                 case OutputType.Png:
                     // http://stackoverflow.com/questions/27267073/imagemagick-lossless-max-compression-for-png
                     image.Quality = 95;

--- a/Application/FileConverter/ConversionPreset/ConversionPreset.cs
+++ b/Application/FileConverter/ConversionPreset/ConversionPreset.cs
@@ -504,6 +504,14 @@ namespace FileConverter
                     break;
 
                 // Images
+                case OutputType.Avif:
+                    this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.ImageQuality, "50");
+                    this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.ImageScale, "1");
+                    this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.ImageRotation, "0");
+                    this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.ImageClampSizePowerOf2, "False");
+                    this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.ImageMaximumSize, "0");
+                    break;
+
                 case OutputType.Gif:
                     this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.VideoScale, "1");
                     this.InitializeSettingsValue(ConversionPreset.ConversionSettingKeys.VideoRotation, "0");

--- a/Application/FileConverter/Helpers.cs
+++ b/Application/FileConverter/Helpers.cs
@@ -20,7 +20,7 @@ namespace FileConverter
     public static class Helpers
     {
         public static readonly string[] CompatibleInputExtensions = {
-            "3gp","3gpp","aac","aiff","ape","arw","avi","bik","bmp","cda","cr2","dds","dng","doc","docx",
+            "3gp","3gpp","aac","aiff","ape","arw","avi","avif","bik","bmp","cda","cr2","dds","dng","doc","docx",
             "exr","flac","flv","gif","heic","ico","jfif","jpg","jpeg","m4a","m4b","m4v","mkv","mov","mp3","mp4",
             "mpg","mpeg","nef","odp","ods","odt","oga","ogg","ogv","opus","pdf","png","ppt","pptx","psd",
             "raf", "rm","svg","tga","tif","tiff", "ts", "vob","wav","webm","webp","wma","wmv","xls","xlsx"
@@ -65,6 +65,7 @@ namespace FileConverter
                     return InputCategoryNames.Video;
 
                 case "arw":
+                case "avif":
                 case "bmp":
                 case "cr2":
                 case "dds":
@@ -212,6 +213,7 @@ namespace FileConverter
                 case OutputType.Webm:
                     return category == InputCategoryNames.Video || category == InputCategoryNames.AnimatedImage;
 
+                case OutputType.Avif:
                 case OutputType.Ico:
                 case OutputType.Jpg:
                 case OutputType.Png:

--- a/Application/FileConverter/OutputType.cs
+++ b/Application/FileConverter/OutputType.cs
@@ -8,6 +8,7 @@ namespace FileConverter
 
         Aac,
         Avi,
+        Avif,
         Flac,
         Gif,
         Ico,

--- a/Application/FileConverter/Settings.default.xml
+++ b/Application/FileConverter/Settings.default.xml
@@ -502,6 +502,7 @@
     <ConversionPreset Name="To Png" OutputType="Png" IsDefaultSettings="true">
         <InputTypes>xcf</InputTypes>
         <InputTypes>arw</InputTypes>
+        <InputTypes>avif</InputTypes>
         <InputTypes>bmp</InputTypes>
         <InputTypes>cr2</InputTypes>
         <InputTypes>dds</InputTypes>
@@ -550,6 +551,7 @@
     <ConversionPreset Name="To Webp" OutputType="Webp" IsDefaultSettings="true">
         <InputTypes>xcf</InputTypes>
         <InputTypes>arw</InputTypes>
+        <InputTypes>avif</InputTypes>
         <InputTypes>bmp</InputTypes>
         <InputTypes>cr2</InputTypes>
         <InputTypes>dds</InputTypes>
@@ -577,9 +579,41 @@
         <Settings Key="ImageMaximumSize" Value="0" />
         <OutputFileNameTemplate>(p)(f)</OutputFileNameTemplate>
     </ConversionPreset>
+    <ConversionPreset Name="To Avif" OutputType="Avif" IsDefaultSettings="true">
+        <InputTypes>xcf</InputTypes>
+        <InputTypes>arw</InputTypes>
+        <InputTypes>avif</InputTypes>
+        <InputTypes>bmp</InputTypes>
+        <InputTypes>cr2</InputTypes>
+        <InputTypes>dds</InputTypes>
+        <InputTypes>dng</InputTypes>
+        <InputTypes>exr</InputTypes>
+        <InputTypes>heic</InputTypes>
+        <InputTypes>ico</InputTypes>
+        <InputTypes>jfif</InputTypes>
+        <InputTypes>jpg</InputTypes>
+        <InputTypes>jpeg</InputTypes>
+        <InputTypes>nef</InputTypes>
+        <InputTypes>png</InputTypes>
+        <InputTypes>psd</InputTypes>
+        <InputTypes>raf</InputTypes>
+        <InputTypes>svg</InputTypes>
+        <InputTypes>tga</InputTypes>
+        <InputTypes>tif</InputTypes>
+        <InputTypes>tiff</InputTypes>
+        <InputTypes>webp</InputTypes>
+        <InputPostConversionAction>None</InputPostConversionAction>
+        <Settings Key="ImageQuality" Value="50" />
+        <Settings Key="ImageScale" Value="1" />
+        <Settings Key="ImageRotation" Value="0" />
+        <Settings Key="ImageClampSizePowerOf2" Value="False" />
+        <Settings Key="ImageMaximumSize" Value="0" />
+        <OutputFileNameTemplate>(p)(f)</OutputFileNameTemplate>
+    </ConversionPreset>
     <ConversionPreset Name="To Jpg" OutputType="Jpg" IsDefaultSettings="true">
         <InputTypes>xcf</InputTypes>
         <InputTypes>arw</InputTypes>
+        <InputTypes>avif</InputTypes>
         <InputTypes>bmp</InputTypes>
         <InputTypes>cr2</InputTypes>
         <InputTypes>dds</InputTypes>


### PR DESCRIPTION
This PR adds support for the AVIF image format to FileConverter. Users can now convert images to and from AVIF format through both the context menu and main application.

Changes:

Added AVIF to supported output formats with quality settings (default 50%)
Added AVIF as input type for all image conversion presets
Uses existing ImageMagick backend for conversion
Includes "To Avif" preset in default configuration
Testing:

Convert JPG/PNG → AVIF ✓
Convert AVIF → JPG/PNG ✓
Context menu shows AVIF options ✓
AVIF provides better compression than JPEG with smaller file sizes, making this a useful addition for modern image workflows.