### PR TITLE
Fix: Nested presets failing with 17+ files due to menu collision

### DIFF
--- a/Application/FileConverterExtension/FileConverterExtension.cs
+++ b/Application/FileConverterExtension/FileConverterExtension.cs
@@ -104,8 +104,11 @@ namespace FileConverterExtension
                 Image = new Icon(Properties.Resources.ApplicationIcon, SystemInformation.SmallIconSize).ToBitmap(),
             };
 
+            int menuItemIndex = 0;
             foreach (MenuEntry menuEntry in this.menuEntries)
             {
+                menuItemIndex++;
+                
                 ToolStripMenuItem root = fileConverterItem;
                 if (menuEntry.PresetReference.Folders != null)
                 {
@@ -142,9 +145,14 @@ namespace FileConverterExtension
                     root = fileConverterItem;
                 }
 
+                // Make each menu item text unique using invisible zero-width spaces
+                // This prevents Windows Forms menu collision while being completely invisible to users
+                string uniqueSuffix = new string('\u200B', menuItemIndex); // Zero-Width Space characters
+                string displayText = menuEntry.PresetReference.Name + uniqueSuffix;
+
                 ToolStripMenuItem subItem = new ToolStripMenuItem
                 {
-                    Text = menuEntry.PresetReference.Name,
+                    Text = displayText,
                     Enabled = menuEntry.Enabled
                 };
 


### PR DESCRIPTION
**Upstream Issue**:
On the current upstream branch, converting 17+ files at once revealed a bug where the program wouldn't necessarily choose the correct conversion profile. The issue lies in Windows Explorer's context menu, which runs an optimization when more than 16 files are selected.

**Explanation of the Bug**:
My investigation suggests that when 16 or less files are selected, Windows Explorer creates the context menu such that each `ToolStripMenuItem` is unique in memory, meaning that even two options with identical `text` properties are still differentiable and execute different conversion presets.

However, with 17+ files, Windows Explorer seems to do an optimization such that multiple instances of `ToolStripMenuItem` with identical `text` properties are __not__ differentiated. I bet Windows assumes that all menu items with identical `text` properties reference the same callback, so it assigns them to the handler of the first item instead of creating separate callbacks. However in this case, multiple `ToolStripMenuItems` with identical `text` properties were __not__, in fact, identical.

**My Workaround**:
To prevent Windows from assigning identically named instances of `ToolStripMenuItem` to the same callback, I added a unique number of invisible zero-width characters to each option. This makes each menu item's `text` property unique while keeping the user interface unchanged. 

**Justification**:
This approach inflicts a relatively minor refactor of just a few lines. While it is a workaround, the "proper" fix would be a major endeavor and refactor. It would probably consist of giving each menu item its own unique command ID or verb at the shell level (`IContextMenu`), but that would either require changes to `SharpShell` or would require writing native code. Suffice to say—major endeavor.

This solution is minimal, doesn’t break existing functionality, and targets a specific, reproducible bug that has been reported at least twice and likely affects all instances of the application. 

**Issues Resolved**:
Fixes #614, #567