### PR TITLE
Fix bugs in UpgradeService

### DIFF
--- a/Application/FileConverter/Services/UpgradeService.cs
+++ b/Application/FileConverter/Services/UpgradeService.cs
@@ -68,6 +68,11 @@ namespace FileConverter.Services
                 Diagnostics.Debug.Log($"Failed to check upgrade: {exception.Message}.");
             }
 
+            if (task == null)
+            {
+                return null;
+            }
+
             UpgradeVersionDescription versionDescription = await task;
 
             if (versionDescription == null)
@@ -155,7 +160,7 @@ namespace FileConverter.Services
         private async Task<UpgradeVersionDescription> DownloadLatestVersionDescription()
         {
 #if BUILD32
-            Uri uri = new Uri(Helpers.BaseURI + "version (x86).xml");
+            Uri uri = new Uri(UpgradeService.BaseURI + "version (x86).xml");
 #else
             Uri uri = new Uri(UpgradeService.BaseURI + "version.xml");
 #endif


### PR DESCRIPTION
This PR fixes two bugs in `UpgradeService`:

1. **NullReferenceException prevention**: Added a null check for the `task` in `CheckForUpgrade` before awaiting it. If `task` is null (e.g., if the upgrade check is not due yet or an error occurred), the method now correctly returns null.
2. **Corrected BaseURI reference**: Fixed a reference to `Helpers.BaseURI` in `DownloadLatestVersionDescription` which was causing a compilation error. It has been replaced with the correct `UpgradeService.BaseURI` reference.