### PR TITLE
Implement auto-retry with software encoding if GPU encoding fails

### DIFF
--- a/Application/FileConverter/ConversionJobs/ConversionJob.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob.cs
@@ -468,6 +468,11 @@ namespace FileConverter.ConversionJobs
             this.ErrorMessage = exitingMessage;
         }
 
+        protected void SetStatusMessage(string message)
+        {
+            this.ErrorMessage = message;
+        }
+
         protected void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
             if (this.PropertyChanged != null)

--- a/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
@@ -23,8 +23,11 @@ namespace FileConverter.ConversionJobs
         private ProcessStartInfo ffmpegProcessStartInfo;
 
         private readonly List<FFMpegPass> ffmpegArgumentStringByPass = new List<FFMpegPass>();
+        private ISettingsService settingsService;
 
-        ISettingsService settingsService = Ioc.Default.GetRequiredService<ISettingsService>();
+        private Helpers.HardwareAccelerationMode currentHardwareAccelerationMode = Helpers.HardwareAccelerationMode.Off;
+        private bool softwareFallbackSucceeded;
+        private string softwareFallbackReason = string.Empty;
 
         public ConversionJob_FFMPEG() : base()
         {
@@ -83,12 +86,16 @@ namespace FileConverter.ConversionJobs
                 RedirectStandardError = true
             };
 
-            this.FillFFMpegArgumentsList();
+            this.currentHardwareAccelerationMode = this.GetSettingsService().Settings.HardwareAccelerationMode;
+            this.softwareFallbackSucceeded = false;
+            this.softwareFallbackReason = string.Empty;
+            this.FillFFMpegArgumentsList(this.currentHardwareAccelerationMode);
         }
 
-        protected virtual void FillFFMpegArgumentsList()
+        protected virtual void FillFFMpegArgumentsList(Helpers.HardwareAccelerationMode hardwareAccelerationMode)
         {
             const string baseArgs = "-n -progress pipe:1";
+            this.ffmpegArgumentStringByPass.Clear();
 
             bool customCommandEnabled = this.ConversionPreset.GetSettingsValue<bool>(ConversionPreset.ConversionSettingKeys.EnableFFMPEGCustomCommand);
             if (customCommandEnabled)
@@ -260,7 +267,7 @@ namespace FileConverter.ConversionJobs
                         VideoEncodingSpeed videoEncodingSpeed = this.ConversionPreset.GetSettingsValue<VideoEncodingSpeed>(ConversionPreset.ConversionSettingKeys.VideoEncodingSpeed);
                         int audioEncodingBitrate = this.ConversionPreset.GetSettingsValue<int>(ConversionPreset.ConversionSettingKeys.AudioBitrate);
 
-                        Helpers.HardwareAccelerationMode hwAccel = settingsService.Settings.HardwareAccelerationMode;
+                        Helpers.HardwareAccelerationMode hwAccel = hardwareAccelerationMode;
 
                         string transformArgs = ConversionJob_FFMPEG.ComputeTransformArgs(this.ConversionPreset, hwAccel);
                         string videoFilteringArgs = ConversionJob_FFMPEG.Encapsulate("-vf", transformArgs);
@@ -432,9 +439,89 @@ namespace FileConverter.ConversionJobs
                 throw new Exception("The conversion preset must be valid.");
             }
 
+            FFMpegExecutionResult executionResult = this.ExecuteFFMpegPasses();
+            if (executionResult.IsSuccess)
+            {
+                this.CleanIntermediateFiles();
+                return;
+            }
+
+            if (this.CanRetryWithSoftwareEncoding(executionResult))
+            {
+                string hardwareFailureReason = executionResult.ErrorMessage;
+
+                this.softwareFallbackReason = hardwareFailureReason;
+                this.UserState = Properties.Resources.GpuEncodingFailedRetryingSoftwareEncode;
+                Diagnostics.Debug.Log("GPU encoding failed. Retry with software libx264 encoder.");
+                Diagnostics.Debug.Log($"GPU encoding failure reason: {hardwareFailureReason}");
+
+                this.DeleteCurrentOutputFileForRetry();
+                this.ResetProgressForRetry();
+                this.currentHardwareAccelerationMode = Helpers.HardwareAccelerationMode.Off;
+                this.FillFFMpegArgumentsList(this.currentHardwareAccelerationMode);
+
+                executionResult = this.ExecuteFFMpegPasses();
+                if (executionResult.IsSuccess)
+                {
+                    this.softwareFallbackSucceeded = true;
+                    this.CleanIntermediateFiles();
+                    return;
+                }
+
+                if (string.IsNullOrEmpty(hardwareFailureReason))
+                {
+                    hardwareFailureReason = "Unknown GPU encoding error.";
+                }
+
+                string softwareFailureReason = executionResult.ErrorMessage;
+                if (string.IsNullOrEmpty(softwareFailureReason))
+                {
+                    softwareFailureReason = "Unknown software encoding error.";
+                }
+
+                Diagnostics.Debug.Log($"Software fallback failure reason: {softwareFailureReason}");
+                this.ConversionFailed(this.BuildEncodeFailureMessage(hardwareFailureReason));
+                this.CleanIntermediateFiles();
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(executionResult.ErrorMessage))
+            {
+                this.ConversionFailed(this.BuildEncodeFailureMessage(executionResult.ErrorMessage));
+            }
+            else
+            {
+                this.ConversionFailed(this.BuildEncodeFailureMessage(string.Empty));
+            }
+
+            this.CleanIntermediateFiles();
+        }
+
+        protected override void OnConversionSucceed()
+        {
+            base.OnConversionSucceed();
+
+            if (!this.softwareFallbackSucceeded)
+            {
+                return;
+            }
+
+            this.UserState = Properties.Resources.ConversionStateDoneSoftwareFallback;
+
+            if (string.IsNullOrEmpty(this.softwareFallbackReason))
+            {
+                this.softwareFallbackReason = "GPU encoder reported an error.";
+            }
+
+            this.SetStatusMessage(Properties.Resources.GpuEncodingFailedAndRetriedWithSoftwareEncoding);
+        }
+
+        private FFMpegExecutionResult ExecuteFFMpegPasses()
+        {
             for (int index = 0; index < this.ffmpegArgumentStringByPass.Count; index++)
             {
                 FFMpegPass currentPass = this.ffmpegArgumentStringByPass[index];
+                string lastErrorMessage = string.Empty;
 
                 this.UserState = currentPass.Name;
                 this.ffmpegProcessStartInfo.Arguments = currentPass.Arguments;
@@ -457,25 +544,139 @@ namespace FileConverter.ConversionJobs
 
                                 string result = reader.ReadLine();
 
-                                this.ParseFFMPEGOutput(result);
+                                string parsedErrorMessage = this.ParseFFMPEGOutput(result);
+                                if (!string.IsNullOrEmpty(parsedErrorMessage))
+                                {
+                                    lastErrorMessage = parsedErrorMessage;
+                                }
 
                                 Diagnostics.Debug.Log($"ffmpeg output: {result}");
                             }
                         }
 
                         exeProcess.WaitForExit();
+
+                        if (this.State == ConversionState.Failed)
+                        {
+                            return new FFMpegExecutionResult(false, this.ErrorMessage);
+                        }
+
+                        if (!string.IsNullOrEmpty(lastErrorMessage))
+                        {
+                            return new FFMpegExecutionResult(false, lastErrorMessage);
+                        }
+
+                        if (exeProcess.ExitCode != 0)
+                        {
+                            if (string.IsNullOrEmpty(lastErrorMessage))
+                            {
+                                lastErrorMessage = $"ffmpeg exited with code {exeProcess.ExitCode}.";
+                            }
+
+                            return new FFMpegExecutionResult(false, lastErrorMessage);
+                        }
                     }
                 }
-                catch
+                catch (Exception exception)
                 {
-                    this.ConversionFailed(Properties.Resources.ErrorFailedToLaunchFFMPEG);
-                    throw;
+                    Diagnostics.Debug.Log(exception.ToString());
+                    return new FFMpegExecutionResult(false, Properties.Resources.ErrorFailedToLaunchFFMPEG);
                 }
             }
 
+            return new FFMpegExecutionResult(true, string.Empty);
+        }
+
+        private bool CanRetryWithSoftwareEncoding(FFMpegExecutionResult executionResult)
+        {
+            if (executionResult.IsSuccess || this.CancelIsRequested || this.State == ConversionState.Failed)
+            {
+                return false;
+            }
+
+            if (this.ConversionPreset == null)
+            {
+                return false;
+            }
+
+            if (this.currentHardwareAccelerationMode == Helpers.HardwareAccelerationMode.Off)
+            {
+                return false;
+            }
+
+            if (!this.GetSettingsService().Settings.AutoRetrySoftwareEncodingOnGpuFailure)
+            {
+                return false;
+            }
+
+            bool customCommandEnabled = this.ConversionPreset.GetSettingsValue<bool>(ConversionPreset.ConversionSettingKeys.EnableFFMPEGCustomCommand);
+            if (customCommandEnabled)
+            {
+                return false;
+            }
+
+            return this.ConversionPreset.OutputType == OutputType.Mp4 || this.ConversionPreset.OutputType == OutputType.Mkv;
+        }
+
+        private string BuildEncodeFailureMessage(string technicalReason)
+        {
+            bool isGpuEncodingPath =
+                this.currentHardwareAccelerationMode != Helpers.HardwareAccelerationMode.Off &&
+                this.ConversionPreset != null &&
+                (this.ConversionPreset.OutputType == OutputType.Mp4 || this.ConversionPreset.OutputType == OutputType.Mkv);
+
+            if (!isGpuEncodingPath)
+            {
+                return string.IsNullOrEmpty(technicalReason) ? Properties.Resources.ErrorConversionFailed : technicalReason;
+            }
+
+            if (this.GetSettingsService().Settings.AutoRetrySoftwareEncodingOnGpuFailure)
+            {
+                return Properties.Resources.ErrorGpuEncodingFailedAfterFallback;
+            }
+
+            return Properties.Resources.ErrorGpuEncodingFailed;
+        }
+
+        private ISettingsService GetSettingsService()
+        {
+            if (this.settingsService == null)
+            {
+                this.settingsService = Ioc.Default.GetRequiredService<ISettingsService>();
+            }
+
+            return this.settingsService;
+        }
+
+        private void DeleteCurrentOutputFileForRetry()
+        {
+            if (!File.Exists(this.OutputFilePath))
+            {
+                return;
+            }
+
+            try
+            {
+                File.Delete(this.OutputFilePath);
+            }
+            catch (Exception exception)
+            {
+                Diagnostics.Debug.Log($"Failed to delete incomplete output file before retry: {this.OutputFilePath}.");
+                Diagnostics.Debug.Log(exception.ToString());
+            }
+        }
+
+        private void ResetProgressForRetry()
+        {
+            this.fileDuration = TimeSpan.Zero;
+            this.actualConvertedDuration = TimeSpan.Zero;
+            this.Progress = 0f;
+        }
+
+        private void CleanIntermediateFiles()
+        {
             Diagnostics.Debug.Log(string.Empty);
 
-            // Clean intermediate files.
             for (int index = 0; index < this.ffmpegArgumentStringByPass.Count; index++)
             {
                 FFMpegPass currentPass = this.ffmpegArgumentStringByPass[index];
@@ -491,8 +692,13 @@ namespace FileConverter.ConversionJobs
             }
         }
 
-        private void ParseFFMPEGOutput(string input)
+        private string ParseFFMPEGOutput(string input)
         {
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
+
             Match match = this.durationRegex.Match(input);
             if (match.Success && match.Groups.Count >= 6)
             {
@@ -502,7 +708,7 @@ namespace FileConverter.ConversionJobs
                 int milliseconds = int.Parse(match.Groups[4].Value) * 10;
                 float bitrate = float.Parse(match.Groups[5].Value);
                 this.fileDuration = new TimeSpan(0, hours, minutes, seconds, milliseconds);
-                return;
+                return string.Empty;
             }
 
             if (this.fileDuration.Ticks > 0)
@@ -521,7 +727,7 @@ namespace FileConverter.ConversionJobs
                     this.actualConvertedDuration = new TimeSpan(0, hours, minutes, seconds, milliseconds);
 
                     this.Progress = this.actualConvertedDuration.Ticks / (float)this.fileDuration.Ticks;
-                    return;
+                    return string.Empty;
                 }
             }
 
@@ -537,8 +743,22 @@ namespace FileConverter.ConversionJobs
                 }
                 else
                 {
-                    this.ConversionFailed(input);
+                    return input;
                 }
+            }
+
+            return string.Empty;
+        }
+
+        private struct FFMpegExecutionResult
+        {
+            public bool IsSuccess;
+            public string ErrorMessage;
+
+            public FFMpegExecutionResult(bool isSuccess, string errorMessage)
+            {
+                this.IsSuccess = isSuccess;
+                this.ErrorMessage = errorMessage;
             }
         }
 

--- a/Application/FileConverter/Properties/Resources.Designer.cs
+++ b/Application/FileConverter/Properties/Resources.Designer.cs
@@ -1506,6 +1506,69 @@ namespace FileConverter.Properties {
                 return ResourceManager.GetString("WebsiteButtonDescription", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-retry software encode if GPU encode fails.
+        /// </summary>
+        public static string AutoRetrySoftwareEncodingOnGpuFailureLabel {
+            get {
+                return ResourceManager.GetString("AutoRetrySoftwareEncodingOnGpuFailureLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to GPU encode failed, retrying software encode.
+        /// </summary>
+        public static string GpuEncodingFailedRetryingSoftwareEncode {
+            get {
+                return ResourceManager.GetString("GpuEncodingFailedRetryingSoftwareEncode", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Done (software fallback).
+        /// </summary>
+        public static string ConversionStateDoneSoftwareFallback {
+            get {
+                return ResourceManager.GetString("ConversionStateDoneSoftwareFallback", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to GPU encoding failed and conversion automatically retried with software encoding..
+        /// </summary>
+        public static string GpuEncodingFailedAndRetriedWithSoftwareEncoding {
+            get {
+                return ResourceManager.GetString("GpuEncodingFailedAndRetriedWithSoftwareEncoding", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to GPU encoding failed. Software fallback also failed. Check hardware acceleration settings or GPU drivers and try again..
+        /// </summary>
+        public static string ErrorGpuEncodingFailedAfterFallback {
+            get {
+                return ResourceManager.GetString("ErrorGpuEncodingFailedAfterFallback", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to GPU encoding failed. Check hardware acceleration settings or GPU drivers and try again..
+        /// </summary>
+        public static string ErrorGpuEncodingFailed {
+            get {
+                return ResourceManager.GetString("ErrorGpuEncodingFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Conversion failed..
+        /// </summary>
+        public static string ErrorConversionFailed {
+            get {
+                return ResourceManager.GetString("ErrorConversionFailed", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to None.

--- a/Application/FileConverter/Properties/Resources.en.resx
+++ b/Application/FileConverter/Properties/Resources.en.resx
@@ -574,4 +574,25 @@ use maj for uppercase version</value>
   <data name="ErrorCantLoadSettings" xml:space="preserve">
     <value>Could not load file converter user settings. Would you like to use default settings ?</value>
   </data>
+  <data name="AutoRetrySoftwareEncodingOnGpuFailureLabel" xml:space="preserve">
+    <value>Auto-retry software encode if GPU encode fails</value>
+  </data>
+  <data name="GpuEncodingFailedRetryingSoftwareEncode" xml:space="preserve">
+    <value>GPU encode failed, retrying software encode</value>
+  </data>
+  <data name="ConversionStateDoneSoftwareFallback" xml:space="preserve">
+    <value>Done (software fallback)</value>
+  </data>
+  <data name="GpuEncodingFailedAndRetriedWithSoftwareEncoding" xml:space="preserve">
+    <value>GPU encoding failed and conversion automatically retried with software encoding.</value>
+  </data>
+  <data name="ErrorGpuEncodingFailedAfterFallback" xml:space="preserve">
+    <value>GPU encoding failed. Software fallback also failed. Check hardware acceleration settings or GPU drivers and try again.</value>
+  </data>
+  <data name="ErrorGpuEncodingFailed" xml:space="preserve">
+    <value>GPU encoding failed. Check hardware acceleration settings or GPU drivers and try again.</value>
+  </data>
+  <data name="ErrorConversionFailed" xml:space="preserve">
+    <value>Conversion failed.</value>
+  </data>
 </root>

--- a/Application/FileConverter/Properties/Resources.resx
+++ b/Application/FileConverter/Properties/Resources.resx
@@ -616,4 +616,25 @@ use maj for uppercase version</value>
   <data name="HardwareAccelerationModeVulkanName" xml:space="preserve">
     <value>Vulkan</value>
   </data>
+  <data name="AutoRetrySoftwareEncodingOnGpuFailureLabel" xml:space="preserve">
+    <value>Auto-retry software encode if GPU encode fails</value>
+  </data>
+  <data name="GpuEncodingFailedRetryingSoftwareEncode" xml:space="preserve">
+    <value>GPU encode failed, retrying software encode</value>
+  </data>
+  <data name="ConversionStateDoneSoftwareFallback" xml:space="preserve">
+    <value>Done (software fallback)</value>
+  </data>
+  <data name="GpuEncodingFailedAndRetriedWithSoftwareEncoding" xml:space="preserve">
+    <value>GPU encoding failed and conversion automatically retried with software encoding.</value>
+  </data>
+  <data name="ErrorGpuEncodingFailedAfterFallback" xml:space="preserve">
+    <value>GPU encoding failed. Software fallback also failed. Check hardware acceleration settings or GPU drivers and try again.</value>
+  </data>
+  <data name="ErrorGpuEncodingFailed" xml:space="preserve">
+    <value>GPU encoding failed. Check hardware acceleration settings or GPU drivers and try again.</value>
+  </data>
+  <data name="ErrorConversionFailed" xml:space="preserve">
+    <value>Conversion failed.</value>
+  </data>
 </root>

--- a/Application/FileConverter/Settings.cs
+++ b/Application/FileConverter/Settings.cs
@@ -23,6 +23,7 @@ namespace FileConverter
         private int maximumNumberOfSimultaneousConversions;
         private bool copyFilesInClipboardAfterConversion = false;
         private Helpers.HardwareAccelerationMode hardwareAccelerationMode = Helpers.HardwareAccelerationMode.Off;
+        private bool autoRetrySoftwareEncodingOnGpuFailure = true;
 
         public ConversionPreset GetPresetFromName(string presetName)
         {
@@ -237,6 +238,22 @@ namespace FileConverter
                 this.OnPropertyChanged();
             }
         }
+
+        [XmlElement]
+        public bool AutoRetrySoftwareEncodingOnGpuFailure
+        {
+            get
+            {
+                return this.autoRetrySoftwareEncodingOnGpuFailure;
+            }
+
+            set
+            {
+                this.autoRetrySoftwareEncodingOnGpuFailure = value;
+                this.OnPropertyChanged();
+            }
+        }
+
         public void OnDeserializationComplete()
         {
             this.DurationBetweenEndOfConversionsAndApplicationExit = System.Math.Max(0, System.Math.Min(10, this.DurationBetweenEndOfConversionsAndApplicationExit));

--- a/Application/FileConverter/Settings.default.xml
+++ b/Application/FileConverter/Settings.default.xml
@@ -2114,4 +2114,5 @@
     </ConversionPreset>
     <CheckUpgradeAtStartup>true</CheckUpgradeAtStartup>
     <CopyFilesInClipboardAfterConversion>false</CopyFilesInClipboardAfterConversion>
+    <AutoRetrySoftwareEncodingOnGpuFailure>true</AutoRetrySoftwareEncodingOnGpuFailure>
 </Settings>

--- a/Application/FileConverter/Views/SettingsWindow.xaml
+++ b/Application/FileConverter/Views/SettingsWindow.xaml
@@ -370,6 +370,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
                     <Label Grid.Row="0" Grid.Column="0" Content="{x:Static project:Resources.Language}" HorizontalAlignment="Right" Margin="0,0,5,0"/>
@@ -410,6 +411,9 @@
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
+
+                    <Label Grid.Row="7" Grid.Column="0" Content="{x:Static project:Resources.AutoRetrySoftwareEncodingOnGpuFailureLabel}" HorizontalAlignment="Right" Margin="0,0,5,0"/>
+                    <CheckBox Grid.Row="7" Grid.Column="1" IsChecked="{Binding Settings.AutoRetrySoftwareEncodingOnGpuFailure, Mode=TwoWay}" Margin="0,5,0,5" />
                 </Grid>
             </TabItem>
 


### PR DESCRIPTION
This PR adds a new feature that automatically retries file conversion using software encoding (libx264) if the initial GPU-accelerated encoding fails. This improves reliability for users with problematic GPU drivers or unsupported hardware configurations.

### Key changes:
- Added `AutoRetrySoftwareEncodingOnGpuFailure` setting (enabled by default).
- Implemented retry logic in `ConversionJob_FFMPEG` to catch GPU errors and fallback to software.
- Added localized status messages and error handling for the fallback process.
- Updated the settings UI with a toggle for this feature.

### Testing:
- Verified that builds succeed.
- Manually tested the fallback mechanism by simulating GPU encoding failures.