### PR TITLE
Fix stdout pipe deadlock in FFmpeg conversion

### DIFF
--- a/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob_FFMPEG.cs
@@ -77,9 +77,9 @@ namespace FileConverter.ConversionJobs
 
             this.ffmpegProcessStartInfo = new ProcessStartInfo(ffmpegPath)
             {
-                CreateNoWindow = true, 
-                UseShellExecute = false, 
-                RedirectStandardOutput = true, 
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = false,
                 RedirectStandardError = true
             };
 
@@ -88,7 +88,7 @@ namespace FileConverter.ConversionJobs
 
         protected virtual void FillFFMpegArgumentsList()
         {
-            const string baseArgs = "-n -progress pipe:1";
+            const string baseArgs = "-n";
 
             bool customCommandEnabled = this.ConversionPreset.GetSettingsValue<bool>(ConversionPreset.ConversionSettingKeys.EnableFFMPEGCustomCommand);
             if (customCommandEnabled)
@@ -424,7 +424,7 @@ namespace FileConverter.ConversionJobs
                 }
             }
         }
-        
+
         protected override void Convert()
         {
             if (this.ConversionPreset == null)


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where FFmpeg conversions hang indefinitely due to a stdout pipe deadlock. The `-progress pipe:1` flag writes progress data to stdout, but the application only reads stderr — causing the pipe buffer to fill and FFmpeg to block on write.

## Key changes
- Removed `-progress pipe:1` from FFmpeg base arguments
- Disabled `RedirectStandardOutput` since stdout is never consumed
- Progress tracking continues to work via stderr legacy format parsing (already implemented)

## Root cause
| Component | Before | After |
|---|---|---|
| `baseArgs` (line 91) | `"-n -progress pipe:1"` | `"-n"` |
| `RedirectStandardOutput` (line 82) | `true` | `false` |

`-progress pipe:1` sends structured progress to stdout, but `Convert()` only reads `StandardError`. Once the stdout pipe buffer fills (~4-64KB), FFmpeg blocks on write → process hangs → output file never finalized (no moov atom for MP4) → unplayable file.

## Impact
- Conversions no longer hang mid-process
- Output files are properly finalized
- No change in progress bar behavior — `ParseFFMPEGOutput` already parses stderr progress (`size=... time=... bitrate=...`)

## Testing
- Verified that the progress regex matches FFmpeg's default stderr output
- Confirmed no other code references `StandardOutput` in the conversion pipeline
- Affected file: `ConversionJob_FFMPEG.cs` (2 lines changed)
