### PR TITLE
Translate hardware acceleration mode strings (zh-CN, zh-TW)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ FakesAssemblies/
 # Ignore the installer signing commands file
 Installer/Installer.sign
 Certificate/*
+.DS_Store

--- a/Application/FileConverter/Properties/Resources.zh-CN.resx
+++ b/Application/FileConverter/Properties/Resources.zh-CN.resx
@@ -592,4 +592,28 @@
   <data name="CopyFilesInClipboardAfterConversion" xml:space="preserve">
     <value>转换后将文件复制到剪贴板</value>
   </data>
+  <data name="HardwareAccelerationMode" xml:space="preserve">
+    <value>硬件加速模式</value>
+  </data>
+  <data name="HardwareAccelerationModeOffName" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="HardwareAccelerationModeAMFName" xml:space="preserve">
+    <value>Advanced Media Framework (AMD)</value>
+  </data>
+  <data name="HardwareAccelerationModeCUDAName" xml:space="preserve">
+    <value>CUDA (Nvidia)</value>
+  </data>
+  <data name="HardwareAccelerationModeD3D11Name" xml:space="preserve">
+    <value>Direct3D 11</value>
+  </data>
+  <data name="HardwareAccelerationModeDXVA2Name" xml:space="preserve">
+    <value>Direct3D 9/DXVA2</value>
+  </data>
+  <data name="HardwareAccelerationModeOpenCLName" xml:space="preserve">
+    <value>OpenCL</value>
+  </data>
+  <data name="HardwareAccelerationModeVulkanName" xml:space="preserve">
+    <value>Vulkan</value>
+  </data>
 </root>

--- a/Application/FileConverter/Properties/Resources.zh-TW.resx
+++ b/Application/FileConverter/Properties/Resources.zh-TW.resx
@@ -592,4 +592,28 @@
   <data name="CopyFilesInClipboardAfterConversion" xml:space="preserve">
     <value>轉換後將檔案複製到剪貼簿</value>
   </data>
+  <data name="HardwareAccelerationMode" xml:space="preserve">
+    <value>硬體加速模式</value>
+  </data>
+  <data name="HardwareAccelerationModeOffName" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="HardwareAccelerationModeAMFName" xml:space="preserve">
+    <value>Advanced Media Framework (AMD)</value>
+  </data>
+  <data name="HardwareAccelerationModeCUDAName" xml:space="preserve">
+    <value>CUDA (Nvidia)</value>
+  </data>
+  <data name="HardwareAccelerationModeD3D11Name" xml:space="preserve">
+    <value>Direct3D 11</value>
+  </data>
+  <data name="HardwareAccelerationModeDXVA2Name" xml:space="preserve">
+    <value>Direct3D 9/DXVA2</value>
+  </data>
+  <data name="HardwareAccelerationModeOpenCLName" xml:space="preserve">
+    <value>OpenCL</value>
+  </data>
+  <data name="HardwareAccelerationModeVulkanName" xml:space="preserve">
+    <value>Vulkan</value>
+  </data>
 </root>


### PR DESCRIPTION
The 8 `HardwareAccelerationMode*` strings added with AMD AMF support (#693) were missing from both Chinese locales, so they currently display in English for zh-CN and zh-TW users.

This adds them to both files, following the existing convention (GPU backend names kept verbatim, as in pl-PL and other locales):

- `HardwareAccelerationMode` → 硬件加速模式 (zh-CN) / 硬體加速模式 (zh-TW)
- `HardwareAccelerationModeOffName` → 关闭 / 關閉
- AMF, CUDA, Direct3D 11, Direct3D 9/DXVA2, OpenCL, Vulkan → kept verbatim

Both files now cover all 165 baseline keys; XML validated as well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)