### PR TITLE
Fix invalid translation options

### DIFF
--- a/Application/FileConverter/App.config
+++ b/Application/FileConverter/App.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="Languages" />
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Fixed the issue where<probing privatePath="Languages"/>was missing in the first<assemblyBinding>tag and before<dependentAssembly>in FileConverter.exe.config, causing language switching failure in the main interface


<img width="1557" height="1041" alt="image" src="https://github.com/user-attachments/assets/9312a11d-f716-450b-85b9-8d361f5b2c19" />

